### PR TITLE
Fix subzero temperature parsing

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -51,7 +51,7 @@ func Protocols() map[string]*Protocol {
 					return nil, err
 				}
 
-				temp, err := strconv.ParseInt(binSeq[16:28], 2, 0)
+				temp, err := parse12BitSignedInt(binSeq[16:28])
 				if err != nil {
 					return nil, err
 				}
@@ -98,7 +98,7 @@ func Protocols() map[string]*Protocol {
 					return nil, err
 				}
 
-				temp, err := strconv.ParseInt(binSeq[12:24], 2, 0)
+				temp, err := parse12BitSignedInt(binSeq[12:24])
 				if err != nil {
 					return nil, err
 				}
@@ -135,4 +135,15 @@ type GTWT01Result struct {
 	Temperature float64
 	Humidity    int
 	LowBattery  bool
+}
+
+func parse12BitSignedInt(s string) (int64, error) {
+	if s[0] == '1' {
+		v, err := strconv.ParseInt(s, 2, 0)
+		if err != nil {
+			return 0, err
+		}
+		return v - 4096, nil // 2**12
+	}
+	return strconv.ParseInt(s, 2, 0)
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -35,3 +35,17 @@ func TestDecode_weather12(t *testing.T) {
 	assert.Equal(t, 1, m.Channel, "Channel")
 	assert.Equal(t, 91, m.ID, "Id")
 }
+
+
+func TestDecode_weather12_negative_temperature(t *testing.T) {
+	p, _ := PreparePulse("592 2036 4080 9000 0 0 0 0 0102010202010201010101010202020202020102020101020202010202020101010202010203")
+	bits, _ := convert(p.Seq, Protocols()["weather12"].Mapping)
+	result, _ := Protocols()["weather12"].Decode(bits)
+	m := result.(*GTWT01Result)
+
+	assert.Equal(t, 110, m.Humidity, "Humidity")
+	assert.Equal(t, -3.9, m.Temperature, "Temperature")
+	assert.Equal(t, false, m.LowBattery, "LowBattery")
+	assert.Equal(t, 1, m.Channel, "Channel")
+	assert.Equal(t, 90, m.ID, "Id")
+}


### PR DESCRIPTION
Parsing of signed integers like temperature was flawed. Due to the uncommon 12bit signed integers, a helper was added.